### PR TITLE
Adds a /is_a/ infix as alias to /of/

### DIFF
--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -10,7 +10,7 @@ class infix(partial):
     def __rtruediv__(self, left):
         return infix(self.func, left)
 
-of = infix(isinstance)
+is_a = of = infix(isinstance)
 contains = infix(lambda lst, item: item in lst)
 pair = infix(lambda a, b: (a, b))
 join = infix(lambda lst, s: s.join(lst))
@@ -76,6 +76,7 @@ def to(start, end):
 __all__ = [
     'infix',
     'of',
+    'is_a',
     'contains',
     'pair',
     'join',

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -7,3 +7,27 @@ def test_str_to_str():
     assert str('A' /to/ 'Z') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 def test_take():
     assert 1 /to/ INF /take/ 5 == [1,2,3,4,5]
+
+def test_is_a():
+    values_types_right = [
+        (2, int),
+        ('strings', str),
+        ({}, dict),
+        ([], list),
+        ((), tuple)
+    ]
+
+    values_types_wrong = [
+        (2, [str, dict, list, tuple]),
+        ('strings', [int, dict, list, tuple]),
+        ({}, [int, str, list, tuple]),
+        ([], [int, str, dict, tuple]),
+        ((), [int, str, dict, list])
+    ]
+
+    for value, type in values_types_right:
+        assert value /is_a/ type
+            
+    for value, types in values_types_wrong:
+        for type in types:
+            assert not value /is_a/ type


### PR DESCRIPTION
`/is_a/` seems to be clearer than `/of/`
It might not be a very important thing to be added at this point in the life of this prototype, but IMO `/is_a/` is clearer than `/of/`
