### PR TITLE
Adds decreasing range and fixes /to/ for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pipe(['google', 'twitter', 'yahoo', 'facebook', 'github'])
 
 ### infix function
 ``` python
-1 /of/ int
+1 /is_a/ int
 # equivalent to `isinstance(1, int)`
 
 1 /to/ 10

--- a/README.md
+++ b/README.md
@@ -72,16 +72,23 @@ pipe(['google', 'twitter', 'yahoo', 'facebook', 'github'])
 
 ### infix function
 ``` python
-1 /is_a/ int
+1 /of/ int
 # equivalent to `isinstance(1, int)`
 
 1 /to/ 10
 # similar to `range(1, 11)`,  but this is an iterator.
 # Python's nasty range() is right-exclusive. This is right-inclusive.
 
+10 /to/ 1
+# similar to `range(10, 0, -1)`, you can also use decreasing ranges
+
 '0' /to/ '9'
 # similar to '0123456789', but this is an iterator.
 # we can also have a range of characters :)
+
+'v' /to/ 'd'
+# similar to 'vutsrqponmlkjihgfed', but this is an iterator
+# e can also have *decreasing* range of characters :)
 ```
 
 `/to/` has some advanced features

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -24,18 +24,20 @@ INF = float('inf')
 
 class To:
     def __init__(self, start, end):
-        if start /of/ int and (end /of/ int or end == INF):
+        valid_char = lambda c: c /of/ str and len(c) == 1
+        valid_integer = lambda i: i /of/ int or i == INF
+
+        if valid_integer(start) and valid_integer(end):
             self.type = 'number'
-            self.start = start
-            self.curr = self.start
-            self.end = end
-        elif start /of/ str and end /of/ str:
+        elif valid_char(start) and valid_char(end):
             self.type = 'char'
-            self.start = start
-            self.curr = self.start
-            self.end = end
         else:
             raise TypeError('Unknown range: %s to %s' % (start, end))
+
+        self.start = start
+        self.curr = self.start
+        self.step = 1 if end > start else -1
+        self.end = end
 
     def __mul__(self, rhs):
         return product(self, rhs)
@@ -45,19 +47,19 @@ class To:
     
     def __next__(self):
         if self.type == 'number':
-            if self.curr <= self.end:
-                ret = self.curr
-                self.curr += 1
-                return ret
-            else:
+            if self.curr == self.end + self.step:
                 raise StopIteration
+            else:
+                ret = self.curr
+                self.curr += self.step
+                return ret
         elif self.type == 'char':
-            if ord(self.curr) <= ord(self.end):
-                ret = self.curr
-                self.curr = chr(ord(self.curr) + 1)
-                return ret
-            else:
+            if ord(self.curr) == ord(self.end) + self.step:
                 raise StopIteration
+            else:
+                ret = self.curr
+                self.curr = chr(ord(self.curr) + self.step)
+                return ret
         else:
             raise StopIteration
     

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -24,6 +24,9 @@ INF = float('inf')
 
 class To:
     def __init__(self, start, end):
+        if start == INF: 
+            raise TypeError('Cannot start range from infinity')
+
         valid_char = lambda c: c /of/ str and len(c) == 1
         valid_integer = lambda i: i /of/ int or i == INF
 

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -49,15 +49,21 @@ class To:
         return self
     
     def __next__(self):
-        if self.type == 'number':
-            if self.curr == self.end + self.step:
+        if self.step == 0 or not self.step /is_a/ int:
+            raise TypeError('Interval must be an integer different from 0')
+        elif self.type == 'number':
+            if self.step >= 0 and self.curr > self.end:
+                raise StopIteration
+            elif self.step <= 0 and self.curr < self.end:
                 raise StopIteration
             else:
                 ret = self.curr
                 self.curr += self.step
                 return ret
         elif self.type == 'char':
-            if ord(self.curr) == ord(self.end) + self.step:
+            if self.step >= 0 and ord(self.curr) > ord(self.end):
+                raise StopIteration
+            elif self.step <= 0 and ord(self.curr) < ord(self.end):
                 raise StopIteration
             else:
                 ret = self.curr

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -1,10 +1,24 @@
+import random
 from syntax_sugar import *
 
 def test_int_to_int():
-    assert list(1 /to/ 10) == list(range(1, 11))
+    for i in range(100):
+        start, end = random.randint(1, 1e3), random.randint(1, 1e3)
+        end += start
+        assert list(start /to/ end) == list(range(start, end + 1))
+
+        start, end = end, start
+        assert list(start /to/ end) == list(range(start, end - 1, -1))
 
 def test_str_to_str():
     assert str('A' /to/ 'Z') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    assert str('Z' /to/ 'A') == 'ZYXWVUTSRQPONMLKJIHGFEDCBA'
+    assert str('a' /to/ 'z') == 'abcdefghijklmnopqrstuvwxyz'
+    assert str('z' /to/ 'a') == 'zyxwvutsrqponmlkjihgfedcba'
+    assert str('D' /to/ 'V') == 'DEFGHIJKLMNOPQRSTUV'
+    assert str('V' /to/ 'D') == 'VUTSRQPONMLKJIHGFED'
+    assert str('v' /to/ 'd') == 'vutsrqponmlkjihgfed'
+
 def test_take():
     assert 1 /to/ INF /take/ 5 == [1,2,3,4,5]
 


### PR DESCRIPTION
Now, the /to/ infix only accepts string ranges of length 1 for each
interval limit. 

Also, decreasing range was added, thus:
```
str('A' /to/ 'Z') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
str('Z' /to/ 'A') == 'ZYXWVUTSRQPONMLKJIHGFEDCBA'
str('a' /to/ 'z') == 'abcdefghijklmnopqrstuvwxyz'
str('z' /to/ 'a') == 'zyxwvutsrqponmlkjihgfedcba'
str('D' /to/ 'V') == 'DEFGHIJKLMNOPQRSTUV'
str('V' /to/ 'D') == 'VUTSRQPONMLKJIHGFED'
str('v' /to/ 'd') == 'vutsrqponmlkjihgfed'

list(1 /to/ 10) == list(range(1, 11))
list(10 /to/ 1) == list(range(10, 0, -1))
```