### PR TITLE
Adds steps to ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pipe(['google', 'twitter', 'yahoo', 'facebook', 'github'])
 10 /to/ 1
 # similar to `range(10, 0, -1)`, you can also use decreasing ranges
 
-10 /to/ 1 /by/ -2
+10 /to/ 1 /by/ 2
 # similar to `range(10, 0, -2)`, you can also specify negative step size
 
 '0' /to/ '9'
@@ -99,7 +99,7 @@ pipe(['google', 'twitter', 'yahoo', 'facebook', 'github'])
 # similar to 'vutsrqponmlkjihgfed', but this is an iterator
 # e can also have *decreasing* range of characters :)
 
-'v' /to/ 'd' /by/ -3
+'v' /to/ 'd' /by/ 3
 # similar to 'vspmjgd', but this is an iterator
 # e can also have *decreasing* range of characters with negative steps
 ```

--- a/README.md
+++ b/README.md
@@ -79,16 +79,29 @@ pipe(['google', 'twitter', 'yahoo', 'facebook', 'github'])
 # similar to `range(1, 11)`,  but this is an iterator.
 # Python's nasty range() is right-exclusive. This is right-inclusive.
 
+1 /to/ 10 /by/ 2
+# similar to `range(1, 11, 2)`, you can also specify step size
+
 10 /to/ 1
 # similar to `range(10, 0, -1)`, you can also use decreasing ranges
+
+10 /to/ 1 /by/ -2
+# similar to `range(10, 0, -2)`, you can also specify negative step size
 
 '0' /to/ '9'
 # similar to '0123456789', but this is an iterator.
 # we can also have a range of characters :)
 
+'A' /to/ 'Z' /by/ 3
+# similar to 'ADGJMPSVY', but this is an iterator. Steps also work for characters!
+
 'v' /to/ 'd'
 # similar to 'vutsrqponmlkjihgfed', but this is an iterator
 # e can also have *decreasing* range of characters :)
+
+'v' /to/ 'd' /by/ -3
+# similar to 'vspmjgd', but this is an iterator
+# e can also have *decreasing* range of characters with negative steps
 ```
 
 `/to/` has some advanced features

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -90,6 +90,17 @@ class To:
 def to(start, end):
     return To(start, end)
 
+@infix
+def by(to_object, step):
+    if to_object.end >= to_object.start and step < 0:
+        raise TypeError('Cannot define increasing ranges with negative step')
+    elif to_object.end <= to_object.start and step > 0:
+        raise TypeError('Cannot define decreasing ranges with positive step')
+    else:
+        to_object.step = step
+        return to_object
+
+
 __all__ = [
     'infix',
     'of',
@@ -98,6 +109,7 @@ __all__ = [
     'pair',
     'join',
     'to',
+    'by',
     'INF',
     'hasattr',
     'fmap',

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -50,12 +50,7 @@ class To:
     def step(self, value):
         if value == 0 or not value /is_a/ int:
             raise TypeError('Interval must be an integer different from 0')
-        if self.end >= self.start and value < 0:
-            self._step = -value
-        elif self.end <= self.start and value > 0:
-            self._step = -value
-        else:
-            self._step = value
+        self._step = value
 
     def __mul__(self, rhs):
         return product(self, rhs)
@@ -105,7 +100,13 @@ def to(start, end):
 
 @infix
 def by(to_object, step):
-    to_object.step = step
+    if to_object.end >= to_object.start and step < 0:
+        to_object.step = -step
+    elif to_object.end <= to_object.start and step > 0:
+        to_object.step = -step
+    else:
+        to_object.step = step
+
     return to_object
 
 

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -51,10 +51,11 @@ class To:
         if value == 0 or not value /is_a/ int:
             raise TypeError('Interval must be an integer different from 0')
         if self.end >= self.start and value < 0:
-            raise TypeError('Cannot define increasing ranges with negative step')
-        if self.end <= self.start and value > 0:
-            raise TypeError('Cannot define decreasing ranges with positive step')
-        self._step = value
+            self._step = -value
+        elif self.end <= self.start and value > 0:
+            self._step = -value
+        else:
+            self._step = value
 
     def __mul__(self, rhs):
         return product(self, rhs)

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -39,8 +39,22 @@ class To:
 
         self.start = start
         self.curr = self.start
-        self.step = 1 if end > start else -1
+        self._step = 1 if end > start else -1
         self.end = end
+
+    @property
+    def step(self):
+        return self._step
+
+    @step.setter
+    def step(self, value):
+        if value == 0 or not value /is_a/ int:
+            raise TypeError('Interval must be an integer different from 0')
+        if self.end >= self.start and value < 0:
+            raise TypeError('Cannot define increasing ranges with negative step')
+        if self.end <= self.start and value > 0:
+            raise TypeError('Cannot define decreasing ranges with positive step')
+        self._step = value
 
     def __mul__(self, rhs):
         return product(self, rhs)
@@ -49,8 +63,6 @@ class To:
         return self
     
     def __next__(self):
-        if self.step == 0 or not self.step /is_a/ int:
-            raise TypeError('Interval must be an integer different from 0')
         def next_number():
             too_big = self.step > 0 and self.curr > self.end
             too_small = self.step < 0 and self.curr < self.end
@@ -92,13 +104,8 @@ def to(start, end):
 
 @infix
 def by(to_object, step):
-    if to_object.end >= to_object.start and step < 0:
-        raise TypeError('Cannot define increasing ranges with negative step')
-    elif to_object.end <= to_object.start and step > 0:
-        raise TypeError('Cannot define decreasing ranges with positive step')
-    else:
-        to_object.step = step
-        return to_object
+    to_object.step = step
+    return to_object
 
 
 __all__ = [

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -29,6 +29,15 @@ def test_str_to_str():
     assert str('V' /to/ 'D') == 'VUTSRQPONMLKJIHGFED'
     assert str('v' /to/ 'd') == 'vutsrqponmlkjihgfed'
 
+def test_str_to_str_with_step():
+    assert str('A' /to/ 'Z' /by/ 3) == 'ADGJMPSVY'
+    assert str('Z' /to/ 'A' /by/ -3) == 'ZWTQNKHEB'
+    assert str('a' /to/ 'z' /by/ 4) == 'aeimquy'
+    assert str('z' /to/ 'a' /by/ -4) == 'zvrnjfb'
+    assert str('D' /to/ 'V' /by/ 5) == 'DINS'
+    assert str('V' /to/ 'D' /by/ -5) == 'VQLG'
+    assert str('v' /to/ 'd' /by/ -3) == 'vspmjgd'
+
 def test_take():
     assert 1 /to/ INF /take/ 5 == [1,2,3,4,5]
 

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -10,6 +10,16 @@ def test_int_to_int():
         start, end = end, start
         assert list(start /to/ end) == list(range(start, end - 1, -1))
 
+def test_int_to_int_with_step():
+    for i in range(100):
+        start, end = random.randint(1, 1e3), random.randint(1, 1e3)
+        step = random.randint(1, 10)
+        end += start
+        assert list(start /to/ end /by/ step) == list(range(start, end + 1, step))
+
+        start, end = end, start
+        assert list(start /to/ end /by/ -step) == list(range(start, end - 1, -step))
+
 def test_str_to_str():
     assert str('A' /to/ 'Z') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
     assert str('Z' /to/ 'A') == 'ZYXWVUTSRQPONMLKJIHGFEDCBA'

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -16,9 +16,11 @@ def test_int_to_int_with_step():
         step = random.randint(1, 10)
         end += start
         assert list(start /to/ end /by/ step) == list(range(start, end + 1, step))
+        assert list(start /to/ end /by/ -step) == list(range(start, end + 1, step))
 
         start, end = end, start
         assert list(start /to/ end /by/ -step) == list(range(start, end - 1, -step))
+        assert list(start /to/ end /by/ step) == list(range(start, end - 1, -step))
 
 def test_str_to_str():
     assert str('A' /to/ 'Z') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -31,12 +33,19 @@ def test_str_to_str():
 
 def test_str_to_str_with_step():
     assert str('A' /to/ 'Z' /by/ 3) == 'ADGJMPSVY'
+    assert str('A' /to/ 'Z' /by/ -3) == 'ADGJMPSVY'
     assert str('Z' /to/ 'A' /by/ -3) == 'ZWTQNKHEB'
+    assert str('Z' /to/ 'A' /by/ 3) == 'ZWTQNKHEB'
     assert str('a' /to/ 'z' /by/ 4) == 'aeimquy'
+    assert str('a' /to/ 'z' /by/ -4) == 'aeimquy'
     assert str('z' /to/ 'a' /by/ -4) == 'zvrnjfb'
+    assert str('z' /to/ 'a' /by/ 4) == 'zvrnjfb'
     assert str('D' /to/ 'V' /by/ 5) == 'DINS'
+    assert str('D' /to/ 'V' /by/ -5) == 'DINS'
     assert str('V' /to/ 'D' /by/ -5) == 'VQLG'
+    assert str('V' /to/ 'D' /by/ 5) == 'VQLG'
     assert str('v' /to/ 'd' /by/ -3) == 'vspmjgd'
+    assert str('v' /to/ 'd' /by/ 3) == 'vspmjgd'
 
 def test_take():
     assert 1 /to/ INF /take/ 5 == [1,2,3,4,5]


### PR DESCRIPTION
Implements the `/by/` syntax for `/to/` range generator, thus:

```python
list(1 /to/ 10 /by/ 2) == [1, 3, 5, 7, 9]
list(10 /to/ 1 /by/ 2) == [10, 8, 6, 4, 2]
str('A' /to/ 'Z' /by/ 3) == 'ADGJMPSVY'
str('Z' /to/ 'A' /by/ -3) == 'ZWTQNKHEB'
```