### PR TITLE
Adds /drop/ syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,16 @@ for i in 1 /to/ INF:
     print(i)
 
 print(1 /to/ INF /take/ 5)
-# there is a `take` funciton which is similar to itertools.islice
+# there is a `take` functon which is similar to itertools.islice
 # return [1, 2, 3, 4, 5]
 
 print(0 /to/ NEGINF /by/ 2 /take/ 5)
 # also works with negative infinity.
 # return [0, -2, -4, -6, -8]
+
+print(1 /to/ 10 /after/ 5)
+# there is a `after` functon which adds an offset to the range beginning
+# return [6, 7, 8, 9, 10]
 
 # print all combinations of [1..3] * [4..6]
 print([(x, y) for x, y in (1 /to/ 3) * (4 /to/ 6)])

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -19,6 +19,7 @@ fmap = infix(flip(map))
 ffilter = infix(flip(filter))
 freduce = infix(flip(reduce))
 take = infix(compose(list, islice))
+after = infix(compose(list, lambda seq, idx: islice(seq, idx, None)))
 
 INF = float('inf')
 NEGINF = float('-inf')
@@ -134,4 +135,5 @@ __all__ = [
     'freduce',
     'ffilter',
     'take',
+    'after',
 ]

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -19,7 +19,7 @@ fmap = infix(flip(map))
 ffilter = infix(flip(filter))
 freduce = infix(flip(reduce))
 take = infix(compose(list, islice))
-after = infix(lambda seq, idx: islice(seq, idx, None))
+drop = infix(lambda seq, idx: islice(seq, idx, None))
 
 INF = float('inf')
 NEGINF = float('-inf')
@@ -135,5 +135,5 @@ __all__ = [
     'freduce',
     'ffilter',
     'take',
-    'after',
+    'drop',
 ]

--- a/syntax_sugar/infix.py
+++ b/syntax_sugar/infix.py
@@ -19,7 +19,7 @@ fmap = infix(flip(map))
 ffilter = infix(flip(filter))
 freduce = infix(flip(reduce))
 take = infix(compose(list, islice))
-after = infix(compose(list, lambda seq, idx: islice(seq, idx, None)))
+after = infix(lambda seq, idx: islice(seq, idx, None))
 
 INF = float('inf')
 NEGINF = float('-inf')

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -85,10 +85,10 @@ def test_infinity():
 def test_take():
     assert 1 /to/ INF /take/ 5 == [1,2,3,4,5]
 
-def test_after():
-    assert list(1 /to/ 10 /after/ 2 /take/ 3) == [3, 4, 5]
-    assert list(1 /to/ INF /after/ 2 /take/ 3) == [3, 4, 5]
-    assert list(10 /to/ 1 /after/ 3 /take/ 2) == [7, 6]
+def test_drop():
+    assert list(1 /to/ 10 /drop/ 2 /take/ 3) == [3, 4, 5]
+    assert list(1 /to/ INF /drop/ 2 /take/ 3) == [3, 4, 5]
+    assert list(10 /to/ 1 /drop/ 3 /take/ 2) == [7, 6]
 
 def test_is_a():
     values_types_right = [

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -85,6 +85,10 @@ def test_infinity():
 def test_take():
     assert 1 /to/ INF /take/ 5 == [1,2,3,4,5]
 
+def test_after():
+    assert list(1 /to/ 10 /after/ 2 /take/ 3) == [3, 4, 5]
+    assert list(10 /to/ 1 /after/ 3 /take/ 2) == [7, 6]
+
 def test_is_a():
     values_types_right = [
         (2, int),

--- a/tests/test_infix.py
+++ b/tests/test_infix.py
@@ -87,6 +87,7 @@ def test_take():
 
 def test_after():
     assert list(1 /to/ 10 /after/ 2 /take/ 3) == [3, 4, 5]
+    assert list(1 /to/ INF /after/ 2 /take/ 3) == [3, 4, 5]
     assert list(10 /to/ 1 /after/ 3 /take/ 2) == [7, 6]
 
 def test_is_a():


### PR DESCRIPTION
It defines an offset to `To` range generator, therefore:

```python
list(1 /to/ 10 /after/ 2) == [3, 4, 5, 6, 7, 8, 9, 10]
list(1 /to/ 10 /after/ 2 /take/ 3) == [3, 4, 5]
```

Things like the following will be possible:
```python
1 /to/ INF /by/ 7 /after/ 32 /take/ 10
```