### PR TITLE
ProcessSyntax poolsize equal to cpu count by default

### DIFF
--- a/syntax_sugar/pipe.py
+++ b/syntax_sugar/pipe.py
@@ -2,6 +2,7 @@ from functools import partial
 from .composable import compose, composable
 from multiprocess.pool import ThreadPool, Pool
 from eventlet import GreenPool
+from multiprocess import cpu_count
 
 __all__ = [
     'END',
@@ -47,7 +48,8 @@ class MultiTaskSyntax:
         return self
 
 class ProcessSyntax(MultiTaskSyntax):
-    pass
+    def __init__(self):
+        self.poolsize = cpu_count()
 
 class ThreadSyntax(MultiTaskSyntax):
     pass


### PR DESCRIPTION
I think this behavior more intuitive and this is what people want by default.